### PR TITLE
atmel-samd: Enable full urandom module from extmod.

### DIFF
--- a/atmel-samd/mpconfigport.h
+++ b/atmel-samd/mpconfigport.h
@@ -52,6 +52,8 @@
 #define MICROPY_PY_MATH             (1)
 #define MICROPY_PY_CMATH            (1)
 #define MICROPY_PY_IO               (0)
+#define MICROPY_PY_URANDOM          (1)
+#define MICROPY_PY_URANDOM_EXTRA_FUNCS (1)
 #define MICROPY_PY_STRUCT           (1)
 #define MICROPY_PY_SYS              (1)
 #define MICROPY_MODULE_FROZEN_MPY   (1)


### PR DESCRIPTION
This is a small change to the port config to enable the urandom module included in the extmod dir.  The full urandom module is enabled so all of its functions are available (the minimum module is too low level and only provides an integer with x random bits, whereas the full module provides the expected python randint, uniform, choice, etc. functions).  

The generator just uses a software random number generator so it's pseudorandom numbers, but that's the best the SAMD21 can do.  You can seed the generator with a value, perhaps like a random ADC reading (although they don't appear to fluctuate much on feathers) or maybe a time.ticks_ms value.

Also of note there is no explicit alias between urandom and random.  IMHO this is fine since this module isn't a complete python random module implementation.

The impact of enabling this module is an increase of about 900 bytes on the firmware size too.